### PR TITLE
Add unit tests to test /api/* endpoints #125

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+# Run the unit test testsuite
+test:
+	docker-compose -f docker-compose.yml run web python manage.py test --verbosity=2

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 # Run the unit test testsuite
+all:
+	docker-compose -f docker-compose.yml build
+	docker-compose -f docker-compose.yml up -d
+
 test:
 	docker-compose -f docker-compose.yml run web python manage.py test --verbosity=2

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ your operating system.
 ## Follow this sequence to get up and running
 
 ```bash
-$ docker-compose -f docker-compose.yml build
-$ docker-compose -f docker-compose.yml up -d
-$ docker-compose -f docker-compose.yml run web python manage.py migrate
-$ docker-compose -f docker-compose.yml run web python manage.py createsuperuser
-$ docker-compose -f docker-compose.yml run web python manage.py cms_setup
-$ docker-compose -f docker-compose.yml run web python manage.py loaddata physical_meetings
-$ docker-compose -f docker-compose.yml run web python manage.py loaddata online_meetings
-$ npm install
-$ npm run build
+docker-compose -f docker-compose.yml build
+docker-compose -f docker-compose.yml up -d
+docker-compose -f docker-compose.yml run web python manage.py migrate
+docker-compose -f docker-compose.yml run web python manage.py createsuperuser
+docker-compose -f docker-compose.yml run web python manage.py cms_setup
+docker-compose -f docker-compose.yml run web python manage.py loaddata physical_meetings
+docker-compose -f docker-compose.yml run web python manage.py loaddata online_meetings
+npm install
+npm run build
 ```
 Go to http://0.0.0.0:8000/
 
@@ -35,7 +35,7 @@ Go to http://0.0.0.0:8000/
 If you need to drop and recreate the postgres database in your docker container do the following:
 
 ```bash
-$ docker-compose -f docker-compose.yml run web python manage.py dbshell
+docker-compose -f docker-compose.yml run web python manage.py dbshell
 ```
 in psql shell
 
@@ -46,5 +46,14 @@ postgres=# CREATE DATABASE aalondon;
 postgres=# exit
 ```
 
+## Running the unit test testsuite
 
+```bash
+docker-compose -f docker-compose.yml run web python manage.py test --verbosity=2
+```
 
+or if you have GNU Make,
+
+```bash
+make test
+```

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,20 +1,18 @@
 from django.test import TestCase
 
 class TestURLSuccess(TestCase):
-    def test_visit_home(self):
-        response = self.client.get('/')
+    """
+    Just test that each api endpoint returns 200
+    """
+    def test_visit_api_root(self):
+        response = self.client.get('/api/')
         assert response.status_code == 200
-    def test_visit_meetings2(self):
-        response = self.client.get('/meetings2/')
-        print (response)
-        # [Tintinnabulate 2020-07-22] XXX:
-        # `response.status_code == 404` because meetingslist2 goes nowhere!
-        # I think you might mean meetingslist3...
+    def test_visit_meetings(self):
+        response = self.client.get('/api/meetings/')
         assert response.status_code == 200
     def test_visit_meetingsearch(self):
-        response = self.client.get('/meetingsearch/')
+        response = self.client.get('/api/meetingsearch/')
         assert response.status_code == 200
     def test_visit_onlinemeetingsearch(self):
-        response = self.client.get('/onlinemeetingsearch/')
+        response = self.client.get('/api/onlinemeetingsearch/')
         assert response.status_code == 200
-    # [Tintinnabulate 2020-07-22] TODO: test rest_framework.urls

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,20 @@
 from django.test import TestCase
 
-# Create your tests here.
+class TestURLSuccess(TestCase):
+    def test_visit_home(self):
+        response = self.client.get('/')
+        assert response.status_code == 200
+    def test_visit_meetings2(self):
+        response = self.client.get('/meetings2/')
+        print (response)
+        # [Tintinnabulate 2020-07-22] XXX:
+        # `response.status_code == 404` because meetingslist2 goes nowhere!
+        # I think you might mean meetingslist3...
+        assert response.status_code == 200
+    def test_visit_meetingsearch(self):
+        response = self.client.get('/meetingsearch/')
+        assert response.status_code == 200
+    def test_visit_onlinemeetingsearch(self):
+        response = self.client.get('/onlinemeetingsearch/')
+        assert response.status_code == 200
+    # [Tintinnabulate 2020-07-22] TODO: test rest_framework.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -12,7 +12,7 @@ router.register(r'meetings', views.MeetingViewSet)
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     path('', include(router.urls)),
-    path('meetings2/',views.MeetingsList.as_view()),
+    path('meetings/',views.MeetingsList.as_view()),
     path('meetingsearch/',views.MeetingSearch.as_view()),
     path('onlinemeetingsearch/',views.OnlineMeetingSearch.as_view()),
     path('', include('rest_framework.urls', namespace='rest_framework'))

--- a/api/views.py
+++ b/api/views.py
@@ -24,18 +24,6 @@ class MeetingViewSet(viewsets.ModelViewSet):
 
 
 
-class MeetingsList3(views.APIView):
-    
-
-    def get(self, request, format=None):
-        """
-        Return a list of all users.
-        """
-        serializer = MeetingSerializer(Meeting.objects.all(), many=True)
-        print(type(serializer.data))
-        meetings = [meeting.title for meeting in Meeting.objects.all()]
-        return Response(serializer.data)
-
 
 class MeetingsList(generics.ListAPIView):
     """


### PR DESCRIPTION
 Add unit tests to test /api/* endpoints #125

* Makefile
Add; two rules, `all`: rebuild and run docker, `test`: run unittests

* api/tests.py
API unit tests for all api endpoints

* api/urls.py
Remove unused URL /meetings2

* api/views.py
Remove unused view /meetings2 mapped to MeetingsList3

Fixes #125 