### PR TITLE
[Docker] Separate step for pip requirements #133

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.7-slim-buster
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+
+# GNUPG is needed to fetch PostgreSQL package from Debian repos.
 RUN set -ex; \
 	if ! command -v gpg > /dev/null; then \
 		apt-get update; \
@@ -11,6 +13,7 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+# Add PostgreSQL gpg key to keyring.
 RUN set -ex; \
 # pub   4096R/ACCC4CF8 2011-10-13 [expires: 2019-07-02]
 #       Key fingerprint = B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
@@ -23,27 +26,42 @@ RUN set -ex; \
 	apt-key list
 
 
-
+# Add PostgreSQL repo.
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list
 	
-COPY requirements.txt requirements.txt
 
+# Build dependencies.
+ARG buildDeps=" \
+build-essential \
+libpq-dev \
+"
+
+# Project dependencies
+ARG deps=" \
+gdal-bin \
+gettext \
+postgresql-client-11 \
+git \
+"
+
+# Install build dependencies and project dependencies.
+# The build dependencies are only needed for the pip install step.
 RUN set -ex \
-    && buildDeps=" \
-       build-essential \
-       libpq-dev \
-    " \
-    && deps=" \
-       gdal-bin \
-       gettext \
-       postgresql-client-11 \
-       git \
-    " \
-    && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install --no-cache-dir -r requirements.txt \
-    && apt-get purge -y --auto-remove $buildDeps \
-       $(! command -v gpg > /dev/null || echo 'gnupg dirmngr') \
-    && rm -rf requirements.txt /var/lib/apt/lists/*
+       && apt-get update \
+       && apt-get install -y $buildDeps $deps --no-install-recommends
+
+
+# pip install step.
+# Install Python library dependencies from requirements.txt
+COPY requirements.txt requirements.txt
+RUN set -ex \
+       && pip install --no-cache-dir -r requirements.txt \
+       && rm -rf requirements.txt /var/lib/apt/lists/*
+
+# Strip the build dependencies from the image.
+RUN set -ex \
+       && apt-get purge -y && apt-get purge -y --auto-remove $buildDeps \
+       $(! command -v gpg > /dev/null || echo 'gnupg dirmngr')
 
 
 WORKDIR /code


### PR DESCRIPTION
Before, the `pip install requirements.txt` command was being run in the
same RUN step as apt-get installing all the build & project
dependencies. This was inefficient - the contents of requirements.txt
changes independently (and more frequently) than the build & project
dependencies, but required a complete reassembly of the docker image.

We now run `pip install requirements.txt` in its own RUN step when
assembling the docker image - so whenever requirements.txt changes, we
only rerun pip install, using the pre-cached apt-get install step from
the previous docker image assembly, thus saving effort & time.

This commit also adds some comments for documentation purposes.