### PR TITLE
Making covid status active by default.

### DIFF
--- a/aalondon/static/js/MeetingSearch.js
+++ b/aalondon/static/js/MeetingSearch.js
@@ -34,7 +34,7 @@ class MeetingSearch extends Component {
     this.state = {
       totalMeetings: 0, currentMeetings: [], currentPage: 1, totalPages: null, day: 'all', showSpinner: 1, intergroup: '',
       clientLng: null, clientLat: null, showPostcode: 1, minMiles: 0, maxMiles: 1000000, geoFail: 0, search: '', 
-      timeBand: 'all', access: '', covid: '', meetingType: ''
+      timeBand: 'all', access: '', covid: 'active', meetingType: ''
     };
   }
 


### PR DESCRIPTION
 Some guy went to an inactive physical meeting so Alan though it best to not show inactive meetings by default.
It sets the state of covid_status = 'active' fro the meeting search React component