### PR TITLE
Populate conference_url #177

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -225,7 +225,7 @@ class MeetingGuideSerializer(serializers.ModelSerializer):
 
     def get_conference_url(self, obj):
         
-        return ""
+        return obj.link
 
     def get_conference_phone(self, obj): return ""
 


### PR DESCRIPTION
This commit populates the `conference_url` field of each meeting in the MeetingGuide api JSON endpoint with `obj.link`.