### PR TITLE
Fix zoom URL regex to capture passwords #186

### DIFF
--- a/scraper/spiders/meeting_spider.py
+++ b/scraper/spiders/meeting_spider.py
@@ -11,7 +11,7 @@ from scrapy.utils.response import open_in_browser
 import datetime
 from meetings.models import Meeting
 
-zoom_pattern = r"https://[\w+?\.]*zoom\.us/j/.+?\b"
+zoom_pattern = r"https://[\w+?\.]*zoom\.us/j/.+?[\?pwd=\w+?]+\b"
 ZOOM_RE = re.compile(zoom_pattern, re.IGNORECASE | re.MULTILINE)
 
 


### PR DESCRIPTION
Capture Zoom URLs with embedded passwords.

* scraper/spiders/meeting_spider.py
(AASpider): Adjust the regex to optionally capture ?pwd=alphanum