### PR TITLE
Render types as JSON array #211

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -226,7 +226,7 @@ class MeetingGuideSerializer(serializers.ModelSerializer):
     def get_conference_phone(self, obj): return ""
 
     def get_types(self, obj):
-        return obj.types
+        return obj.get_types()
 
     def get_location(self, obj): return ""
     def get_location_notes(self, obj): return ""

--- a/meetings/models.py
+++ b/meetings/models.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 from django_extensions.db.fields import AutoSlugField
 from datetime import time
+import json
 
 # Create your models here.
 
@@ -61,5 +62,6 @@ class Meeting(models.Model):
         self.types = json.dumps(x)
 
     def get_types(self):
-        return json.loads(self.types)
+        # JSON only supports double-quoted values
+        return json.loads(self.types.replace("'", "\""))
 

--- a/scraper/spiders/meeting_spider.py
+++ b/scraper/spiders/meeting_spider.py
@@ -155,7 +155,7 @@ class AASpider(scrapy.Spider):
 
         if "Women" in meeting_data['detail']:
             types.append("W") #  Women's meeting
-        elif "Men" in meeting_data['detail']:
+        elif "Men's" in meeting_data['detail'] or "Mens" in meeting_data['detail']:
             types.append("M") #  Men's meeting
 
         if "Outdoor" in meeting_data['detail']:


### PR DESCRIPTION
* api/serializers.py
* meetings/models.py
* scraper/spiders/meeting_spider.py
Render types as JSON array, also fix problem with categorising all
 meetings with string "Men" as a men's meeting (e.g. "Mental"!).