### PR TITLE
Meetingguide json suffix

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -19,3 +19,6 @@ class TestURLSuccess(TestCase):
     def test_visit_meetingguide(self):
         response = self.client.get('/api/meetingguide/')
         assert response.status_code == 200
+    def test_visit_meetingguide_json(self):
+        response = self.client.get('/api/meetingguide.json')
+        assert response.status_code == 200

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,6 +4,7 @@ from api import views
 
 router = routers.DefaultRouter()
 router.register(r'meetings', views.MeetingViewSet)
+router.register(r'meetingguide', views.MeetingGuideViewSet)
 
 
 app_name = "api"

--- a/api/views.py
+++ b/api/views.py
@@ -187,4 +187,13 @@ class MeetingGuideListView(generics.ListAPIView):
     queryset = Meeting.objects.all()
     pagination_class = None
 
-    
+
+class MeetingGuideViewSet(viewsets.ModelViewSet):
+    """
+    Provide a ViewSet for Django Default Router so that MeetingGuide endpoint
+    can be accessed with `.json` suffix.
+    """
+
+    queryset = Meeting.objects.all()
+    serializer_class = MeetingGuideSerializer
+    pagination_class = None


### PR DESCRIPTION
We now provide a `/api/meetingguide.json` URL to access the MeetingGuide API using a `ModelViewSet`

This also adds a return code `200` test  to the API testsuite.