### PR TITLE
Experiment with adding city & state #250

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -165,6 +165,8 @@ class MeetingGuideSerializer(serializers.ModelSerializer):
     paypal = serializers.SerializerMethodField()
     last_contact = serializers.SerializerMethodField()
     postal_code = serializers.SerializerMethodField()
+    city = serializers.SerializerMethodField()
+    state = serializers.SerializerMethodField()
     country = serializers.SerializerMethodField()
     timezone = serializers.SerializerMethodField()
 
@@ -177,7 +179,7 @@ class MeetingGuideSerializer(serializers.ModelSerializer):
                        'district_id', 'sub_district', 'group_notes', 'website', 'website_2',
                          'location_url', 'formatted_address', 'latitude', 'longitude',
                         'email', 'phone', 'mailing_address', 'venmo', 'square', 'paypal',
-                       'last_contact','postal_code','country', 'timezone']
+                       'last_contact','postal_code', 'city', 'state', 'country', 'timezone']
                   
 
     def get_id(self, obj):
@@ -260,6 +262,12 @@ class MeetingGuideSerializer(serializers.ModelSerializer):
     def get_last_contact(self, obj): return ""
     def get_postal_code(self, obj): 
         return obj.postcode
+
+    def get_city(self, obj):
+        return obj.intergroup
+
+    def get_state(self, obj):
+        return "London"
     
     def get_country(self, obj): 
         return "UK"


### PR DESCRIPTION
This commit is an experiment.

App Support are seeing a bunch of "approximate location" errors. Meeting
Guide website suggests using an approximate location by adding the city,
state and country, but leaving the address field blank. See below:

<https://meetingguide.aa.org/online-meetings>

* api/serializers.py
(MeetingGuideSerializer): Populate city, state and country fields:
  city = intergroup
  state = "London"
  country = "UK"