### PR TITLE
Default meeting search to Now on load

### DIFF
--- a/aalondon/static/js/MeetingSearch.js
+++ b/aalondon/static/js/MeetingSearch.js
@@ -32,7 +32,7 @@ class MeetingSearch extends Component {
 
 
     this.state = {
-      totalMeetings: 0, currentMeetings: [], currentPage: 1, totalPages: null, day: 'all', showSpinner: 1, intergroup: '',
+      totalMeetings: 0, currentMeetings: [], currentPage: 1, totalPages: null, day: 'now', showSpinner: 1, intergroup: '',
       clientLng: null, clientLat: null, showPostcode: 1, minMiles: 0, maxMiles: 1000000, geoFail: 0, search: '', 
       timeBand: 'all', access: '', covid: 'active', meetingType: ''
     };


### PR DESCRIPTION
Alan upon feedback from users would like the default behaviour to be "Now" on load

![image](https://user-images.githubusercontent.com/1273523/103151224-09bb9980-4774-11eb-8a9f-cec900e93e10.png)

